### PR TITLE
[WIP] Incorrect trimming in tags

### DIFF
--- a/test.js
+++ b/test.js
@@ -22,6 +22,11 @@ cleaner.clean(' foo\n', function (html) {
     assert.equal(html, 'foo');
 });
 
+// test that output is not trimmed in tags
+cleaner.clean('<p>I<strong> love</stong> Paris!</p>', function (html) {
+    assert.equal(html, '<p>I<strong> love Paris!</strong></p>');
+});
+
 // test that directive is unchanged
 cleaner.clean('<!DOCTYPE html>', function (html) {
     assert.equal(html, '<!DOCTYPE html>')


### PR DESCRIPTION
Hi,
We detected a weird behavior related to trimming inside HTML tags. It could lead to unexpected whitespaces removal.

Here is a test case illustrating the issue, if it is ok to you I can try to find a fix after digging in the code (except if it is obvious to you :) ).

PS : while I am at it, would you be interested in a following PR with Prettier formatting for the codebase?