### PR TITLE
Add options for formatting Angular components

### DIFF
--- a/index.js
+++ b/index.js
@@ -404,10 +404,10 @@ function clean(html, opt, callback) {
             throw err;
         }
 
-        var html = render(dom);
-        html = indent(html).trim();
+        var output = render(dom);
+        output = indent(output).trim();
 
-        callback(html);
+        callback(output);
     });
 
     var parser = new htmlparser.Parser(handler);

--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,16 @@ Sanity restored!
 
 ## Options
 
+### allow-attributes-without-values
+
+Allows attributes to be output without values.  For example, `checked` instead
+of `checked=""`.
+
+Please set to `true` for Angular components or for `<input>` elements.
+
+Type: Boolean
+Default: `false`
+
 ### break-around-comments
 
 Adds line breaks before and after comments.
@@ -112,6 +122,24 @@ The string to use for indentation. e.g., a tab character or one or more spaces.
 
 Type: String  
 Default: `'  '` (two spaces)
+
+### lower-case-tags
+
+Converts all tag names to lower case.
+
+Please set to `false` for Angular components.
+
+Type: Boolean
+Default: `true`
+
+### lower-case-attribute-names
+
+Converts all attribute names to lower case.
+
+Please set to `false` for Angular components.
+
+Type: Boolean
+Default: `true`
 
 ### remove-attributes
 


### PR DESCRIPTION
These new options allow us to format Angular components without breaking them:

 * `allow-attributes-without-values` - when true, formats attributes like angular hashtags without adding empty values: `#foo` instead of `#foo=""`
 * `lower-case-tags` - when false, preserves case in tag names that correspond to components: `app-fooBar` instead of `app-foobar`
 * `lower-case-attribute-names` - when false, preserves case in attribute names, which can be important in hash tags and other case-sensitive custom attributes: `#fooBar` instead of `#foobar` or `fooBar="baz"` instead of `foobar="baz"`

The default values are such that backward compatibility is preserved.